### PR TITLE
Adapt github actions to the uppercase repo name

### DIFF
--- a/.github/workflows/image-push-master.yaml
+++ b/.github/workflows/image-push-master.yaml
@@ -1,8 +1,5 @@
 name: "push an image on merge to master"
 
-env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}
-
 on:
   push:
     branches:
@@ -12,6 +9,10 @@ jobs:
     name: image push amd64
     runs-on: ubuntu-22.04
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: check out the repo
         uses: actions/checkout@v3
 
@@ -32,13 +33,17 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ env.IMAGE_NAME }}:latest-amd64
+            ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-amd64
           file: ./Dockerfile
 
   build-and-push-arm64-k8s-rdma-shared-dev-plugin:
     name: image push arm64
     runs-on: ubuntu-22.04
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: check out the repo
         uses: actions/checkout@v3
 
@@ -59,13 +64,17 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: |
-            ${{ env.IMAGE_NAME }}:latest-arm64
+            ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-arm64
           file: ./Dockerfile
 
   build-and-push-ppc64le-k8s-rdma-shared-dev-plugin:
     name: image push ppc64le
     runs-on: ubuntu-22.04
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: check out the repo
         uses: actions/checkout@v3
 
@@ -86,13 +95,17 @@ jobs:
           push: true
           platforms: linux/ppc64le
           tags: |
-            ${{ env.IMAGE_NAME }}:latest-ppc64le
+            ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-ppc64le
           file: ./Dockerfile
 
   push-manifest:
     runs-on: ubuntu-22.04
     needs: [build-and-push-amd64-k8s-rdma-shared-dev-plugin,build-and-push-arm64-k8s-rdma-shared-dev-plugin,build-and-push-ppc64le-k8s-rdma-shared-dev-plugin]
     steps:
+    - name: Set repository as lower-case output variable
+      id: repo_name
+      run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
     - name: set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -105,7 +118,7 @@ jobs:
 
     - name: Create manifest for multi-arch images
       run: |
-        docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:latest -t ${{ env.IMAGE_NAME }}:sha-${{ github.sha }} \
-        ${{ env.IMAGE_NAME }}:latest-amd64 \
-        ${{ env.IMAGE_NAME }}:latest-arm64 \
-        ${{ env.IMAGE_NAME }}:latest-ppc64le
+        docker buildx imagetools create -t ghcr.io/${{ steps.repo_name.outputs.repository }}:latest -t ghcr.io/${{ steps.repo_name.outputs.repository }}:sha-${{ github.sha }} \
+        ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-amd64 \
+        ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-arm64 \
+        ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-ppc64le

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,6 @@
 
 name: Publish Docker image
 
-env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}
-
 on:
   push:
     tags:
@@ -18,6 +15,9 @@ jobs:
     name: Push amd64 image to ghcr.io
     runs-on: ubuntu-latest
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
       - name: Check out the repo
         uses: actions/checkout@v3
 
@@ -35,7 +35,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
           tags: |
@@ -55,6 +55,10 @@ jobs:
     name: Push arm64 image to ghcr.io
     runs-on: ubuntu-latest
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Check out the repo
         uses: actions/checkout@v3
 
@@ -72,7 +76,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
           tags: |
@@ -92,6 +96,10 @@ jobs:
     name: Push ppc64le image to ghcr.io
     runs-on: ubuntu-latest
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Check out the repo
         uses: actions/checkout@v3
 
@@ -109,7 +117,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
           tags: |
@@ -129,6 +137,10 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build-and-push-amd64,build-and-push-arm64,build-and-push-ppc64le]
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -136,7 +148,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
           tags: |

--- a/images/k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       containers:
-      - image: mellanox/k8s-rdma-shared-dev-plugin
+      - image: ghcr.io/mellanox/k8s-rdma-shared-dev-plugin
         name: k8s-rdma-shared-dp-ds
         imagePullPolicy: IfNotPresent
         securityContext:


### PR DESCRIPTION
Docker cannot work with uppercased letters in the images names, so we need to lowercase the repo name before proceeding with images pushes

Also, adapt the daemonset config to take the image from ghcr